### PR TITLE
Add ability to see how many people are connected to the room

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -16,7 +16,7 @@ from chat.components.messages import ChatMessage, RoomUnavailableError, ErrorMes
     JoinChannelMessage
 from chat.components.serializables import ChatUser
 from chat.models import Room, HistoryRecord
-from chat.views import check_permission
+from chat.permissions import check_permission
 
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):

--- a/chat/permissions.py
+++ b/chat/permissions.py
@@ -1,0 +1,10 @@
+"""Permission checking for use in chat"""
+# pylint: disable=unused-argument,fixme
+# TODO: Implement permissions for chat
+from base.models.ifuser import IFUser
+from chat.models import Room
+
+
+def check_permission(room: Room, user: IFUser) -> bool:
+    """Checks if user has permission for said room"""
+    return True

--- a/chat/templates/chat/index.html
+++ b/chat/templates/chat/index.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     <h1>Dostupné místnosti</h1>
-    {% for room in rooms %}
-        <a href="{% url 'chat:single_room' room_name=room.name %}">{{ room.name|title }}</a>
+    {% for room_info in rooms %}
+        <a href="{% url 'chat:single_room' room_name=room_info.name %}">{{ room_info.name|title }} ({{room_info.users}})</a>
     {% endfor %}
 {% endblock %}

--- a/chat/views.py
+++ b/chat/views.py
@@ -8,8 +8,9 @@ from django.http import Http404
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
 
-from base.models.ifuser import IFUser
+from chat.consumers import ChatConsumer
 from chat.models import Room
+from chat.permissions import check_permission
 
 
 @login_required
@@ -21,14 +22,12 @@ def list_rooms(request):
     for room in rooms:
         if check_permission(room, user):
             room_list.append(room)
+    users_list = ChatConsumer.users
+    room_list = map(lambda room: {
+        "name": room.name,
+        "users": len(users_list.get(room.name, {}))
+    }, room_list)
     return render(request, 'chat/index.html', {"rooms": room_list})
-
-
-# pylint: disable=unused-argument,fixme
-# TODO: Implement permissions for chat
-def check_permission(room: Room, user: IFUser) -> bool:
-    """Checks if user has permission for said room"""
-    return True
 
 
 @login_required


### PR DESCRIPTION
* Add ability to see how many people are connected to the room
  * Will not work correctly with multiple processes but should be enough for now
* Move checking permissions for chat into separate module, as it was creating cyclic dependency.
  * It also never made sense to have it there as `ChatConsumer` used it also and permission checking was not bound to views only.